### PR TITLE
Fix build warnings: UIDeviceFamily plist key and NSLock in async contexts

### DIFF
--- a/NoteDraft/NoteDraft/Info.plist
+++ b/NoteDraft/NoteDraft/Info.plist
@@ -16,10 +16,6 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>UIDeviceFamily</key>
-	<array>
-		<integer>2</integer>
-	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations~ipad</key>

--- a/NoteDraft/NoteDraft/Services/PDFStorageService.swift
+++ b/NoteDraft/NoteDraft/Services/PDFStorageService.swift
@@ -220,9 +220,7 @@ class PDFStorageService {
         let key = CacheKey(pdfName: pdfName, pageIndex: index, size: size)
 
         // Check cache first
-        cacheLock.lock()
-        let cached = cache.value(for: key)
-        cacheLock.unlock()
+        let cached = cachedImage(for: key)
         if let cached { return cached }
 
         // Dispatch heavy work to the global concurrent executor via a child task so:
@@ -243,9 +241,7 @@ class PDFStorageService {
                 let image = self.renderPDFPage(page, at: size)
 
                 if let image {
-                    self.cacheLock.lock()
-                    self.cache.insert(image, for: key)
-                    self.cacheLock.unlock()
+                    self.storeCachedImage(image, for: key)
                 }
                 return image
             }
@@ -332,6 +328,18 @@ class PDFStorageService {
         cacheLock.lock()
         defer { cacheLock.unlock() }
         cache.removeAll()
+    }
+
+    private func cachedImage(for key: CacheKey) -> UIImage? {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        return cache.value(for: key)
+    }
+
+    private func storeCachedImage(_ image: UIImage, for key: CacheKey) {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        cache.insert(image, for: key)
     }
 
     // MARK: - Private helpers


### PR DESCRIPTION
Two warnings were present that would become build errors under Swift 6 strict concurrency mode. This PR addresses both.

**`Info.plist` - remove `UIDeviceFamily`**

Xcode emits a warning when `UIDeviceFamily` is set in `Info.plist` because it overrides the build setting. The `TARGETED_DEVICE_FAMILY = 2` entry already exists in `project.pbxproj` for all configurations, so the plist key was redundant and is now removed.

**`PDFStorageService` - `NSLock` in async contexts**

`cacheLock.lock()` / `cacheLock.unlock()` were called directly inside `async` methods (`renderPage`, `flushCache`). Swift warns that these are unavailable from async contexts and treats this as an error in Swift 6 mode.

The fix extracts the lock/unlock pairs into two private synchronous helpers (`cachedImage(for:)` and `storeCachedImage(_:for:)`). Calling a synchronous function from an async context is fine -- the lock operations are no longer visible from the async scope. Behaviour is identical.