### PR TITLE
Optimize continuous mode by reusing PageViewModels

### DIFF
--- a/NoteDraft/NoteDraft.xcodeproj/project.pbxproj
+++ b/NoteDraft/NoteDraft.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		B2A2A2A2A2A2A2A2A2A2A2A2 /* NotebookViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B2B2B2B2B2B2B2B2B2B2B2 /* NotebookViewModel.swift */; };
 		B3A3A3A3A3A3A3A3A3A3A3A3 /* PageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B3B3B3B3B3B3B3B3B3B3B3 /* PageView.swift */; };
 		B4A4A4A4A4A4A4A4A4A4A4A4 /* PageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B4B4B4B4B4B4B4B4B4B4B4 /* PageViewModel.swift */; };
+		BA0D95472E9C4E85AA4F6F11 /* PageViewModelCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA4D2058B2646A8A6CE4D31 /* PageViewModelCache.swift */; };
 		B5A5A5A5A5A5A5A5A5A5A5A5 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B5B5B5B5B5B5B5B5B5B5B5 /* CanvasView.swift */; };
 		B6A6A6A6A6A6A6A6A6A6A6A6 /* ContinuousPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B6B6B6B6B6B6B6B6B6B6B6 /* ContinuousPageView.swift */; };
 		B7A7A7A7A7A7A7A7A7A7A7A7 /* NotebookPageScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B7B7B7B7B7B7B7B7B7B7B7 /* NotebookPageScrollView.swift */; };
@@ -62,6 +63,7 @@
 		B2B2B2B2B2B2B2B2B2B2B2B2 /* NotebookViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookViewModel.swift; sourceTree = "<group>"; };
 		B3B3B3B3B3B3B3B3B3B3B3B3 /* PageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageView.swift; sourceTree = "<group>"; };
 		B4B4B4B4B4B4B4B4B4B4B4B4 /* PageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewModel.swift; sourceTree = "<group>"; };
+		BCA4D2058B2646A8A6CE4D31 /* PageViewModelCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewModelCache.swift; sourceTree = "<group>"; };
 		B5B5B5B5B5B5B5B5B5B5B5B5 /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		B6B6B6B6B6B6B6B6B6B6B6B6 /* ContinuousPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousPageView.swift; sourceTree = "<group>"; };
 		B7B7B7B7B7B7B7B7B7B7B7B7 /* NotebookPageScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookPageScrollView.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				2C3254771E6143F0AC310D24 /* NotebookListViewModel.swift */,
 				B2B2B2B2B2B2B2B2B2B2B2B2 /* NotebookViewModel.swift */,
 				B4B4B4B4B4B4B4B4B4B4B4B4 /* PageViewModel.swift */,
+				BCA4D2058B2646A8A6CE4D31 /* PageViewModelCache.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -323,6 +326,7 @@
 				B3A3A3A3A3A3A3A3A3A3A3A3 /* PageView.swift in Sources */,
 				A1052B2C5FD445CDA238BF98 /* AsyncContentImage.swift in Sources */,
 				B4A4A4A4A4A4A4A4A4A4A4A4 /* PageViewModel.swift in Sources */,
+				BA0D95472E9C4E85AA4F6F11 /* PageViewModelCache.swift in Sources */,
 				B5A5A5A5A5A5A5A5A5A5A5A5 /* CanvasView.swift in Sources */,
 				B6A6A6A6A6A6A6A6A6A6A6A6 /* ContinuousPageView.swift in Sources */,
 				B8A8A8A8A8A8A8A8A8A8A8A8 /* BackgroundView.swift in Sources */,

--- a/NoteDraft/NoteDraft/ViewModels/PageViewModelCache.swift
+++ b/NoteDraft/NoteDraft/ViewModels/PageViewModelCache.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@MainActor
+final class PageViewModelCache {
+    private var cache: [UUID: PageViewModel] = [:]
+
+    /// Returns a stable `PageViewModel` instance for the given page.
+    /// The first request creates and caches the model; subsequent requests
+    /// for the same page ID return that same instance so redraws do not
+    /// reset page-level state (e.g. lazy drawing-load flags).
+    func viewModel(for page: Page, notebookViewModel: NotebookViewModel) -> PageViewModel {
+        if let existing = cache[page.id] {
+            return existing
+        }
+
+        let created = notebookViewModel.createPageViewModel(for: page)
+        cache[page.id] = created
+        return created
+    }
+
+    func prune(keeping validPageIDs: Set<UUID>) {
+        cache = cache.filter { validPageIDs.contains($0.key) }
+    }
+
+    func clear() {
+        cache.removeAll()
+    }
+}

--- a/NoteDraft/NoteDraft/Views/ContinuousPageView.swift
+++ b/NoteDraft/NoteDraft/Views/ContinuousPageView.swift
@@ -11,6 +11,7 @@ import PencilKit
 struct ContinuousPageView: View {
     @ObservedObject var notebookViewModel: NotebookViewModel
     @State private var pageViewModelCache = ContinuousPageViewModelCache()
+    private let cacheRetainRadius = 1
     
     private var navigationTitleText: String {
         guard !notebookViewModel.notebook.pages.isEmpty else {
@@ -57,15 +58,18 @@ struct ContinuousPageView: View {
                 }
                 .coordinateSpace(name: "scroll")
                 .onAppear {
-                    pageViewModelCache.prune(keeping: Set(notebookViewModel.notebook.pages.map(\.id)))
+                    prunePageViewModelCache()
                     // Scroll to the saved page position when view appears
                     if notebookViewModel.currentPageIndex >= 0 && notebookViewModel.currentPageIndex < notebookViewModel.notebook.pages.count {
                         let pageId = notebookViewModel.notebook.pages[notebookViewModel.currentPageIndex].id
                         scrollProxy.scrollTo(pageId, anchor: .top)
                     }
                 }
-                .onChange(of: notebookViewModel.notebook.pages.map(\.id)) { _, pageIDs in
-                    pageViewModelCache.prune(keeping: Set(pageIDs))
+                .onChange(of: notebookViewModel.notebook.pages.map(\.id)) { _, _ in
+                    prunePageViewModelCache()
+                }
+                .onChange(of: notebookViewModel.currentPageIndex) { _, _ in
+                    prunePageViewModelCache()
                 }
                 .onChange(of: notebookViewModel.programmaticScrollTarget) { _, target in
                     // Respond to programmatic scroll requests (e.g., after a PDF import).
@@ -89,6 +93,19 @@ struct ContinuousPageView: View {
         }
         .navigationTitle(navigationTitleText)
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func prunePageViewModelCache() {
+        pageViewModelCache.prune(keeping: retainedPageIDs(around: notebookViewModel.currentPageIndex))
+    }
+
+    private func retainedPageIDs(around centerIndex: Int) -> Set<UUID> {
+        let pages = notebookViewModel.notebook.pages
+        guard !pages.isEmpty else { return [] }
+        let clampedCenterIndex = min(max(centerIndex, 0), pages.count - 1)
+        let lowerBound = max(0, clampedCenterIndex - cacheRetainRadius)
+        let upperBound = min(pages.count - 1, clampedCenterIndex + cacheRetainRadius)
+        return Set((lowerBound...upperBound).map { pages[$0].id })
     }
 }
 

--- a/NoteDraft/NoteDraft/Views/ContinuousPageView.swift
+++ b/NoteDraft/NoteDraft/Views/ContinuousPageView.swift
@@ -10,6 +10,7 @@ import PencilKit
 
 struct ContinuousPageView: View {
     @ObservedObject var notebookViewModel: NotebookViewModel
+    @State private var pageViewModelCache = ContinuousPageViewModelCache()
     
     private var navigationTitleText: String {
         guard !notebookViewModel.notebook.pages.isEmpty else {
@@ -26,7 +27,7 @@ struct ContinuousPageView: View {
                         ForEach(Array(notebookViewModel.notebook.pages.enumerated()), id: \.element.id) { index, page in
                             GeometryReader { pageGeometry in
                                 PageContentView(
-                                    viewModel: notebookViewModel.createPageViewModel(for: page),
+                                    viewModel: pageViewModelCache.viewModel(for: page, notebookViewModel: notebookViewModel),
                                     pageNumber: index + 1
                                 )
                                 .onChange(of: pageGeometry.frame(in: .named("scroll")).minY) { oldValue, newValue in
@@ -56,11 +57,15 @@ struct ContinuousPageView: View {
                 }
                 .coordinateSpace(name: "scroll")
                 .onAppear {
+                    pageViewModelCache.prune(keeping: Set(notebookViewModel.notebook.pages.map(\.id)))
                     // Scroll to the saved page position when view appears
                     if notebookViewModel.currentPageIndex >= 0 && notebookViewModel.currentPageIndex < notebookViewModel.notebook.pages.count {
                         let pageId = notebookViewModel.notebook.pages[notebookViewModel.currentPageIndex].id
                         scrollProxy.scrollTo(pageId, anchor: .top)
                     }
+                }
+                .onChange(of: notebookViewModel.notebook.pages.map(\.id)) { _, pageIDs in
+                    pageViewModelCache.prune(keeping: Set(pageIDs))
                 }
                 .onChange(of: notebookViewModel.programmaticScrollTarget) { _, target in
                     // Respond to programmatic scroll requests (e.g., after a PDF import).
@@ -78,6 +83,9 @@ struct ContinuousPageView: View {
                     }
                 }
             }
+        }
+        .onDisappear {
+            pageViewModelCache.clear()
         }
         .navigationTitle(navigationTitleText)
         .navigationBarTitleDisplayMode(.inline)
@@ -97,6 +105,29 @@ struct PageDivider: View {
         }
         .padding(.vertical, 8)
         .background(Color(UIColor.systemGroupedBackground))
+    }
+}
+
+@MainActor
+private final class ContinuousPageViewModelCache {
+    private var cache: [UUID: PageViewModel] = [:]
+
+    func viewModel(for page: Page, notebookViewModel: NotebookViewModel) -> PageViewModel {
+        if let existing = cache[page.id] {
+            return existing
+        }
+
+        let created = notebookViewModel.createPageViewModel(for: page)
+        cache[page.id] = created
+        return created
+    }
+
+    func prune(keeping validPageIDs: Set<UUID>) {
+        cache = cache.filter { validPageIDs.contains($0.key) }
+    }
+
+    func clear() {
+        cache.removeAll()
     }
 }
 

--- a/NoteDraft/NoteDraft/Views/ContinuousPageView.swift
+++ b/NoteDraft/NoteDraft/Views/ContinuousPageView.swift
@@ -10,7 +10,7 @@ import PencilKit
 
 struct ContinuousPageView: View {
     @ObservedObject var notebookViewModel: NotebookViewModel
-    @State private var pageViewModelCache = ContinuousPageViewModelCache()
+    @State private var pageViewModelCache = PageViewModelCache()
     private let cacheRetainRadius = 1
     
     private var navigationTitleText: String {
@@ -122,29 +122,6 @@ struct PageDivider: View {
         }
         .padding(.vertical, 8)
         .background(Color(UIColor.systemGroupedBackground))
-    }
-}
-
-@MainActor
-private final class ContinuousPageViewModelCache {
-    private var cache: [UUID: PageViewModel] = [:]
-
-    func viewModel(for page: Page, notebookViewModel: NotebookViewModel) -> PageViewModel {
-        if let existing = cache[page.id] {
-            return existing
-        }
-
-        let created = notebookViewModel.createPageViewModel(for: page)
-        cache[page.id] = created
-        return created
-    }
-
-    func prune(keeping validPageIDs: Set<UUID>) {
-        cache = cache.filter { validPageIDs.contains($0.key) }
-    }
-
-    func clear() {
-        cache.removeAll()
     }
 }
 

--- a/NoteDraft/NoteDraft/Views/NotebookPageScrollView.swift
+++ b/NoteDraft/NoteDraft/Views/NotebookPageScrollView.swift
@@ -114,30 +114,3 @@ struct NotebookPageScrollView: View {
         return Set((lowerBound...upperBound).map { pages[$0].id })
     }
 }
-
-@MainActor
-private final class PageViewModelCache {
-    private var cache: [UUID: PageViewModel] = [:]
-
-    /// Returns a stable `PageViewModel` instance for the given page.
-    /// The first request creates and caches the model; subsequent requests
-    /// for the same page ID return that same instance so redraws do not
-    /// reset page-level state (e.g. lazy drawing-load flags).
-    func viewModel(for page: Page, notebookViewModel: NotebookViewModel) -> PageViewModel {
-        if let existing = cache[page.id] {
-            return existing
-        }
-
-        let created = notebookViewModel.createPageViewModel(for: page)
-        cache[page.id] = created
-        return created
-    }
-
-    func prune(keeping validPageIDs: Set<UUID>) {
-        cache = cache.filter { validPageIDs.contains($0.key) }
-    }
-
-    func clear() {
-        cache.removeAll()
-    }
-}


### PR DESCRIPTION
## What changed
- Added a per-page `PageViewModel` cache in `ContinuousPageView`.
- Replaced per-render `createPageViewModel(for:)` calls with cached retrieval by page ID.
- Added cache pruning when notebook page IDs change.
- Cleared cache when leaving continuous mode.

## Why this is the highest-impact, lowest-effort fix
`ContinuousPageView` previously created fresh `PageViewModel` instances during scroll-driven body updates. That repeatedly rebuilt per-page state (drawing load flags, image cache state, memory-warning observers), which is expensive and can cause UI churn with larger notebooks. Caching by page ID removes that repeated work with a small, localized change.

## 10 performance improvements identified
| # | Improvement | Impact | Effort |
|---|---|---|---|
| 1 | **Reuse `PageViewModel` instances in `ContinuousPageView`** (implemented here) | High | Low |
| 2 | Debounce/threshold page-index updates from geometry changes in continuous scroll | High | Medium |
| 3 | Persist notebooks in per-notebook files (avoid rewriting all notebooks on every page mutation) | High | High |
| 4 | Remove JSON `.prettyPrinted` writes in `DataStore` to reduce encode/write cost | Medium | Low |
| 5 | Add dirty-checking in `saveDrawing()` to skip no-op notebook writes | Medium | Low |
| 6 | Share a `PKToolPicker` instance instead of creating one per canvas | Medium | Low |
| 7 | Replace `[String: UIImage]` image cache with `NSCache` + memory cost limits | Medium | Medium |
| 8 | Add lightweight in-memory memoization for frequently accessed page lookups in save paths | Medium | Medium |
| 9 | Move expensive background/grid/lined drawing to reusable cached layers for large page counts | Medium | Medium |
| 10 | Tune PDF cache sizing adaptively by memory pressure/device class instead of fixed 10 entries | Medium | Medium |

## Validation
- `xcodebuild test -project NoteDraft/NoteDraft.xcodeproj -scheme NoteDraft -destination 'id=1E5C55BF-1455-4D31-9A5A-90E02715DFCB'`
- Result: **TEST SUCCEEDED**